### PR TITLE
resolve workspace.root deprecation warning

### DIFF
--- a/src/actions/utils/openFiles.ts
+++ b/src/actions/utils/openFiles.ts
@@ -8,21 +8,11 @@ const openFiles = async (files: string[]) => {
   }
   for (const filePath of files) {
     try {
-      // TODO figure out why this does not work
-      // 	try {
-      // 		const absoluteFilePath = join(workspaceRoot.uri.path, filePath)
-      // 		const doc = await vscode.workspace.openTextDocument(absoluteFilePath)
-      // 		await vscode.window.showTextDocument(doc, vscode.ViewColumn.One)
-      // 		// there are times when initialization leave the panel behind any files opened
-      // 		// ensure the panel is redrawn on the right side first
-      // 		// webview.createOrShow()
-      // 	} catch (error) {
-      // 		console.log(`Failed to open file ${filePath}`, error)
-      // 	}
-      const wr = vscode.workspace.rootPath
-      if (!wr) {
-        throw new Error('No workspace root path')
+      const workspaceFolders: vscode.WorkspaceFolder[] | undefined = vscode.workspace.workspaceFolders
+      if (!workspaceFolders || !workspaceFolders.length) {
+        throw new Error('No workspace directory. Open a workspace directory and try again')
       }
+      const wr: string = workspaceFolders[0].uri.path
       const absoluteFilePath = join(wr, filePath)
       const doc = await vscode.workspace.openTextDocument(absoluteFilePath)
       await vscode.window.showTextDocument(doc, vscode.ViewColumn.One)


### PR DESCRIPTION
Resolve warning for deprecated workspace.root by using workspaceFolders[0].uri.path