### PR TITLE
move notification into status bar

### DIFF
--- a/src/editor/commands.ts
+++ b/src/editor/commands.ts
@@ -1,5 +1,6 @@
 import * as T from 'typings'
 import * as vscode from 'vscode'
+import notify from '../services/notify'
 import createTestRunner, { Payload } from '../services/testRunner'
 import createWebView from '../webview'
 
@@ -56,13 +57,13 @@ export const createCommands = ({ extensionPath, workspaceState, workspaceRoot }:
       testRunner = createTestRunner(config, {
         onSuccess: (payload: Payload) => {
           // send test pass message back to client
-          vscode.window.showInformationMessage('PASS')
+          notify({ message: 'PASS' })
           webview.send({ type: 'TEST_PASS', payload })
           // update local storage
         },
         onFail: (payload: Payload, message: string) => {
           // send test fail message back to client
-          vscode.window.showWarningMessage(`FAIL ${message}`)
+          notify({ message: `FAIL ${message}` })
           webview.send({ type: 'TEST_FAIL', payload })
         },
         onError: (payload: Payload) => {

--- a/src/services/notify/index.ts
+++ b/src/services/notify/index.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode'
+
+interface Props {
+  message: string
+}
+
+const notify = ({ message }: Props) => {
+  vscode.window.setStatusBarMessage(message, 15000)
+}
+
+export default notify


### PR DESCRIPTION
Move notifications into the status bar.

Stops bug with modal notifications where:
- notifications pile up because notifications have no way of programmatically dismissing
- notifications are annoying