### PR TITLE
distinguish between auth network & server errors

### DIFF
--- a/web-app/src/services/state/actions/api.ts
+++ b/web-app/src/services/state/actions/api.ts
@@ -32,19 +32,28 @@ export default {
       })
       .catch(error => {
         onError(error)
-        console.error('ERROR: Authentication failed')
-        console.error(error)
+        console.log('ERROR: Authentication failed')
+        console.log(error.message)
+        let message
+        if (error.message.match(/Network error:/)) {
+          message = {
+            title: 'Network Error',
+            description: 'Make sure you have an Internet connection. Restart and try again',
+          }
+        } else {
+          message = {
+            title: 'Server Error',
+            description: error.message,
+          }
+        }
+        channel.receive({ data: { type: 'ERROR', payload: { error: message } } })
+        return
       })
 
     if (!result || !result.data) {
-      // TODO handle failed authentication
-      console.error('ERROR: Connection')
-      const error = {
-        title: 'Connection Failed',
-        description:
-          'Either our server is having issues or you may not be connected to the internet. Try checking your connection and restarting the application. ',
-      }
-      channel.receive({ data: { type: 'ERROR', payload: { error } } })
+      const error = new Error('Authentication request responded with no data')
+      console.log(error)
+      onError(error)
       return
     }
     const { token } = result.data.editorLogin


### PR DESCRIPTION
Closes #79 

There's currently an error component that looks like this: https://github.com/ShMcK/coderoad-vscode/blob/master/web-app/src/components/Error/index.tsx

It will display any errors.

In this case the message is a bit unclear, but comes from a custom error: https://github.com/ShMcK/coderoad-vscode/blob/master/web-app/src/services/state/actions/api.ts#L45

Possible causes of authentication failure on startup include:
- internet not connected
- server not responding
- authentication failed (unlikely to happen)

The error didn't distinguish between server issues & network issues (bad/no connection). It should work now.

