### PR TITLE
Validate tutorial dependencies

### DIFF
--- a/errors/MissingTutorialDependency.md
+++ b/errors/MissingTutorialDependency.md
@@ -1,0 +1,3 @@
+### Missing Tutorial Dependency
+
+The tutorial cannot run because it a dependency is not yet installed. Install the dependency and click "Check Again".

--- a/errors/UnmetTutorialDependency.md
+++ b/errors/UnmetTutorialDependency.md
@@ -1,0 +1,5 @@
+### Unmet Tutorial Dependency
+
+### Unmet Tutorial Dependency
+
+Tutorial cannot reun because a dependency version doesn't match. Install the correct dependency and click "Check Again".

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,11 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1003,6 +1008,14 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ=="
     },
+    "@types/semver": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.1.0.tgz",
+      "integrity": "sha512-pOKLaubrAEMUItGNpgwl0HMFPrSAFic8oSVIvfu1UwcgGNmNyK9gyhBHKmBnUTwwVvpZfkzUC0GaMgnL6P86uA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -1701,6 +1714,13 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "cssom": {
@@ -5335,9 +5355,9 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.2.2.tgz",
+      "integrity": "sha512-Zo84u6o2PebMSK3zjJ6Zp5wi8VnQZnEaCP13Ul/lt1ANsLACxnJxq4EEm1PY94/por1Hm9+7xpIswdS5AkieMA=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -6120,6 +6140,12 @@
               }
             }
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         },
         "vscode-test": {
           "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/jest": "^25.2.1",
     "@types/jsdom": "^16.2.0",
     "@types/node": "^13.11.0",
+    "@types/semver": "^7.1.0",
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",
     "chokidar": "^3.3.0",
@@ -49,6 +50,7 @@
     "jest": "^25.2.7",
     "jsdom": "^16.2.2",
     "prettier": "^2.0.2",
+    "semver": "^7.2.2",
     "ts-jest": "^25.3.1",
     "typescript": "^3.8.3"
   },

--- a/src/channel/index.ts
+++ b/src/channel/index.ts
@@ -94,6 +94,8 @@ class Channel implements Channel {
         // setup tutorial config (save watcher, test runner, etc)
         await this.context.setTutorial(this.workspaceState, data)
 
+        // validate dependencies
+
         const error: E.ErrorMessage | void = await tutorialConfig({ config: data.config }).catch((error: Error) => ({
           type: 'UnknownError',
           message: `Location: tutorial config.\n\n${error.message}`,

--- a/src/channel/index.ts
+++ b/src/channel/index.ts
@@ -9,7 +9,7 @@ import tutorialConfig from '../actions/tutorialConfig'
 import { COMMANDS } from '../editor/commands'
 import logger from '../services/logger'
 import Context from './context'
-import { version as gitVersion } from '../services/git'
+import { version } from '../services/dependencies'
 import { openWorkspace, checkWorkspaceEmpty } from '../services/workspace'
 import { readFile } from 'fs'
 import { join } from 'path'
@@ -146,7 +146,7 @@ class Channel implements Channel {
         }
         // 2. check Git is installed.
         // Should wait for workspace before running otherwise requires access to root folder
-        const isGitInstalled = await gitVersion()
+        const isGitInstalled = await version('git')
         if (!isGitInstalled) {
           const error: E.ErrorMessage = {
             type: 'GitNotFound',

--- a/src/services/dependencies/index.ts
+++ b/src/services/dependencies/index.ts
@@ -1,25 +1,24 @@
-import * as TT from 'typings/tutorial'
 import { satisfies } from 'semver'
 import node from '../node'
 
 const semverRegex = /(?<=^v?|\sv?)(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*)(?:\.(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*))*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?(?=$|\s)/gi
 
 export const version = async (name: string): Promise<string | null> => {
-  const { stdout, stderr } = await node.exec(`${name} --version`)
-  if (!stderr) {
-    const match = stdout.match(semverRegex)
-    if (match) {
-      return match[0]
+  try {
+    const { stdout, stderr } = await node.exec(`${name} --version`)
+    if (!stderr) {
+      const match = stdout.match(semverRegex)
+      if (match) {
+        return match[0]
+      }
     }
+    return null
+  } catch (error) {
+    return null
   }
-  return null
 }
 
 export const compareVersions = async (currentVersion: string, expectedVersion: string): Promise<never | boolean> => {
   // see node-semver docs: https://github.com/npm/node-semver
-  const satisfied: boolean = satisfies(currentVersion, expectedVersion)
-  if (!satisfied) {
-    throw new Error(`Expected ${name} to have version ${expectedVersion}, but found version ${currentVersion}`)
-  }
-  return true
+  return satisfies(currentVersion, expectedVersion)
 }

--- a/src/services/dependencies/index.ts
+++ b/src/services/dependencies/index.ts
@@ -15,19 +15,7 @@ export const version = async (name: string): Promise<string | null> => {
   return null
 }
 
-export const compareVersions = async ({
-  name,
-  version: expectedVersion,
-  message,
-}: TT.TutorialDependency): Promise<boolean> => {
-  const currentVersion = await version(name)
-  if (!currentVersion) {
-    // use a custom error message
-    if (message) {
-      throw new Error(message)
-    }
-    throw new Error(`Process ${name} is required but not found. It may need to be installed`)
-  }
+export const compareVersions = async (currentVersion: string, expectedVersion: string): Promise<never | boolean> => {
   // see node-semver docs: https://github.com/npm/node-semver
   const satisfied: boolean = satisfies(currentVersion, expectedVersion)
   if (!satisfied) {

--- a/src/services/dependencies/index.ts
+++ b/src/services/dependencies/index.ts
@@ -1,0 +1,14 @@
+import node from '../node'
+
+const semverRegex = /(?<=^v?|\sv?)(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*)(?:\.(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*))*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?(?=$|\s)/gi
+
+export const getVersion = async (name: string): Promise<string | null> => {
+  const { stdout, stderr } = await node.exec(`${name} --version`)
+  if (!stderr) {
+    const match = stdout.match(semverRegex)
+    if (match) {
+      return match[0]
+    }
+  }
+  return null
+}

--- a/src/services/git/index.ts
+++ b/src/services/git/index.ts
@@ -69,19 +69,6 @@ export async function clear(): Promise<Error | void> {
   throw new Error('Error cleaning up current unsaved work')
 }
 
-export async function version(): Promise<string | null> {
-  const { stdout, stderr } = await node.exec('git --version')
-  if (!stderr) {
-    const match = stdout.match(/^git version (\d+\.)?(\d+\.)?(\*|\d+)/)
-    if (match) {
-      // eslint-disable-next-line
-      const [_, major, minor, patch] = match
-      return `${major}${minor}${patch}`
-    }
-  }
-  return null
-}
-
 async function init(): Promise<Error | void> {
   const { stderr } = await node.exec('git init')
   if (stderr) {

--- a/typings/tutorial.d.ts
+++ b/typings/tutorial.d.ts
@@ -3,6 +3,7 @@ export type Maybe<T> = T | null
 export type TutorialConfig = {
   testRunner: TutorialTestRunner
   repo: TutorialRepo
+  dependencies?: TutorialDependency[]
 }
 
 /** Logical groupings of tasks */
@@ -56,4 +57,9 @@ export interface TutorialTestRunner {
 export interface TutorialRepo {
   uri: string
   branch: string
+}
+
+export interface TutorialDependency {
+  name: string
+  version: string
 }

--- a/typings/tutorial.d.ts
+++ b/typings/tutorial.d.ts
@@ -62,4 +62,5 @@ export interface TutorialRepo {
 export interface TutorialDependency {
   name: string
   version: string
+  message?: string
 }


### PR DESCRIPTION
closes #223.

- [x] Run a validation of tutorial dependencies on startup. Use semver to compare ranges, and capture the version by running `name --version` in a child process.

- [ ] Note, should also be added to the coderoad-parser.

Signed-off-by: shmck <shawn.j.mckay@gmail.com>