### PR TITLE
add an option to build on windows

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,16 @@ tsc -p ./
 cd web-app
 npm run build
 cd ..
+
+# For Windows build: switch the next 2 lines
+if [[ "$OSTYPE" == "msys" ]]; then
+echo "linux subsystem on windows selected"
+cp -R ./web-app/build/ ./
+else
+echo "Unix system selected"
 cp -R ./web-app/build/ ./build/
+fi
+
 node scripts/fixFontPaths.js
 
 echo "Build complete!"


### PR DESCRIPTION
The options are not comprehensive for all builds. If the person tries to build using the regular Windows CMD it will fail.

Signed-off-by: argemiront <argemiront@gmail.com>