### PR TITLE
support VSCode 1.39.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [0.2.3]
 
 - Support Windows OS
+
+## [0.2.4]
+
+- Support VSCode 1.39.2 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Install CodeRoad from [this link in the VSCode Marketplace](https://marketplace.
 ### Requirements
 
 - OS: MacOS, Windows, Linux
-- VSCode 1.40+
+- VSCode 1.39.2+
 - Node.js 10+
 - Git
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coderoad",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coderoad",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Play interactive coding tutorials in your editor",
   "keywords": [
     "tutorial",
@@ -58,7 +58,7 @@
     "vscode-test": "^1.3.0"
   },
   "engines": {
-    "vscode": "^1.44.0"
+    "vscode": "^1.39.2"
   },
   "activationEvents": [
     "onCommand:coderoad.start"

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coderoad-app",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coderoad-app",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "scripts": {
     "build": "react-app-rewired build",


### PR DESCRIPTION
Closes #264 

Tested by downloading [VSCode 1.39.2](https://code.visualstudio.com/updates/v1_39) and works!

Will release as v0.2.4.

Signed-off-by: shmck <shawn.j.mckay@gmail.com>