### PR TITLE
Validate app versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,4 +48,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [0.2.4]
 
-- Support VSCode 1.39.2 
+- Support VSCode 1.39.2
+
+## [0.3.0]
+
+- Validate the extension version against the tutorial config version. This should allow us to manage breaking changes in tutorial schema in upcoming versions

--- a/errors/GitProjectAlreadyExists.md
+++ b/errors/GitProjectAlreadyExists.md
@@ -1,5 +1,5 @@
-### Git Project Already Exists
+### Git Remote Already Exists
 
-CodeRoad requires an empty Git project.
+Have you started this tutorial before in this workspace? The Git remote already exists.
 
-Open a new workspace to start a tutorial.
+Consider deleting your `.git` folder and restarting.

--- a/errors/GitRemoteAlreadyExists.md
+++ b/errors/GitRemoteAlreadyExists.md
@@ -1,0 +1,5 @@
+### Git Project Already Exists
+
+CodeRoad requires an empty Git project.
+
+Open a new workspace to start a tutorial.

--- a/errors/UnmetExtensionVersion.md
+++ b/errors/UnmetExtensionVersion.md
@@ -1,0 +1,3 @@
+### Unmet Tutorial Dependency
+
+This tutorial requires a different version of CodeRoad.

--- a/errors/UnmetTutorialDependency.md
+++ b/errors/UnmetTutorialDependency.md
@@ -1,5 +1,3 @@
 ### Unmet Tutorial Dependency
 
-### Unmet Tutorial Dependency
-
 Tutorial cannot reun because a dependency version doesn't match. Install the correct dependency and click "Check Again".

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coderoad",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coderoad",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Play interactive coding tutorials in your editor",
   "keywords": [
     "tutorial",

--- a/src/channel/index.ts
+++ b/src/channel/index.ts
@@ -113,7 +113,7 @@ class Channel implements Channel {
           const data: TT.Tutorial = action.payload.tutorial
 
           // validate extension version
-          const expectedAppVersion = data.config?.appVersions?.coderoadVSCode
+          const expectedAppVersion = data.config?.appVersions?.vscode
           if (expectedAppVersion) {
             const extension = vscode.extensions.getExtension('coderoad.coderoad')
             if (extension) {
@@ -122,7 +122,7 @@ class Channel implements Channel {
               if (!satisfied) {
                 const error: E.ErrorMessage = {
                   type: 'UnmetExtensionVersion',
-                  message: `Expected CodeRoad v${expectedAppVersion}, but found ${currentAppVersion}`,
+                  message: `Expected CodeRoad v${expectedAppVersion}, but found v${currentAppVersion}`,
                 }
                 this.send({ type: 'TUTORIAL_CONFIGURE_FAIL', payload: { error } })
                 return

--- a/src/channel/index.ts
+++ b/src/channel/index.ts
@@ -2,6 +2,7 @@ import * as T from 'typings'
 import * as TT from 'typings/tutorial'
 import * as E from 'typings/error'
 import * as vscode from 'vscode'
+import { satisfies } from 'semver'
 import saveCommit from '../actions/saveCommit'
 import setupActions from '../actions/setupActions'
 import solutionActions from '../actions/solutionActions'
@@ -110,6 +111,25 @@ class Channel implements Channel {
       case 'EDITOR_TUTORIAL_CONFIG':
         try {
           const data: TT.Tutorial = action.payload.tutorial
+
+          // validate extension version
+          const expectedAppVersion = data.config?.appVersions?.coderoadVSCode
+          if (expectedAppVersion) {
+            const extension = vscode.extensions.getExtension('coderoad.coderoad')
+            if (extension) {
+              const currentAppVersion = extension.packageJSON.version
+              const satisfied = satisfies(currentAppVersion, expectedAppVersion)
+              if (!satisfied) {
+                const error: E.ErrorMessage = {
+                  type: 'UnmetExtensionVersion',
+                  message: `Expected CodeRoad v${expectedAppVersion}, but found ${currentAppVersion}`,
+                }
+                this.send({ type: 'TUTORIAL_CONFIGURE_FAIL', payload: { error } })
+                return
+              }
+            }
+          }
+
           // setup tutorial config (save watcher, test runner, etc)
           await this.context.setTutorial(this.workspaceState, data)
 
@@ -121,7 +141,7 @@ class Channel implements Channel {
               const currentVersion: string | null = await version(dep.name)
               if (!currentVersion) {
                 // use a custom error message
-                const error = {
+                const error: E.ErrorMessage = {
                   type: 'MissingTutorialDependency',
                   message:
                     dep.message || `Process "${dep.name}" is required but not found. It may need to be installed`,
@@ -140,7 +160,7 @@ class Channel implements Channel {
               const satisfiedDependency = await compareVersions(currentVersion, dep.version)
 
               if (!satisfiedDependency) {
-                const error = {
+                const error: E.ErrorMessage = {
                   type: 'UnmetTutorialDependency',
                   message: `Expected ${dep.name} to have version ${dep.version}, but found version ${currentVersion}`,
                   actions: [
@@ -155,7 +175,7 @@ class Channel implements Channel {
               }
 
               if (satisfiedDependency !== true) {
-                const error = satisfiedDependency || {
+                const error: E.ErrorMessage = satisfiedDependency || {
                   type: 'UnknownError',
                   message: `Something went wrong comparing dependency for ${name}`,
                   actions: [

--- a/typings/error.d.ts
+++ b/typings/error.d.ts
@@ -1,13 +1,16 @@
 export type ErrorMessageView = 'FULL_PAGE' | 'NOTIFY' | 'NONE'
 
 export type ErrorMessageType =
-  | 'UnknownError'
-  | 'NoWorkspaceFound'
-  | 'GitNotFound'
-  | 'WorkspaceNotEmpty'
   | 'FailedToConnectToGitRepo'
+  | 'GitNotFound'
   | 'GitProjectAlreadyExists'
   | 'GitRemoteAlreadyExists'
+  | 'MissingTutorialDependency'
+  | 'NoWorkspaceFound'
+  | 'UnknownError'
+  | 'UnmetExtensionVersion'
+  | 'UnmetTutorialDependency'
+  | 'WorkspaceNotEmpty'
 
 export type ErrorAction = {
   label: string

--- a/typings/tutorial.d.ts
+++ b/typings/tutorial.d.ts
@@ -1,6 +1,7 @@
 export type Maybe<T> = T | null
 
 export type TutorialConfig = {
+  appVersions: TutorialAppVersions
   testRunner: TutorialTestRunner
   repo: TutorialRepo
   dependencies?: TutorialDependency[]
@@ -63,4 +64,8 @@ export interface TutorialDependency {
   name: string
   version: string
   message?: string
+}
+
+export interface TutorialAppVersions {
+  coderoadVSCode: string
 }

--- a/typings/tutorial.d.ts
+++ b/typings/tutorial.d.ts
@@ -67,5 +67,5 @@ export interface TutorialDependency {
 }
 
 export interface TutorialAppVersions {
-  coderoadVSCode: string
+  vscode: string
 }

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coderoad-app",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coderoad-app",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "build": "react-app-rewired build",


### PR DESCRIPTION
Validate the extension version against the tutorial config version. This should allow us to manage breaking changes in tutorial schema in upcoming versions. See [node-semver](https://github.com/npm/node-semver#advanced-range-syntax) for possible version ranges and options.

```json
{
"config": {
  "appVersions": {
    "vscode": "<0.2"
  },
}
```

To be released as v0.3.0