### PR TITLE
Traverse content (blocked)

### DIFF
--- a/src/channel/index.ts
+++ b/src/channel/index.ts
@@ -297,6 +297,11 @@ class Channel implements Channel {
         vscode.commands.executeCommand(COMMANDS.RUN_TEST)
         return
 
+      case 'EDITOR_SYNC_PROGRESS':
+        // update progress when a level is deemed complete in the client
+        await this.context.progress.syncProgress(action.payload.progress)
+        return
+
       default:
         logger(`No match for action type: ${actionType}`)
         return

--- a/src/channel/state/Progress.ts
+++ b/src/channel/state/Progress.ts
@@ -39,6 +39,10 @@ class Progress {
   public reset = () => {
     this.set(defaultValue)
   }
+  public syncProgress = (progress: T.Progress): T.Progress => {
+    const next = { ...this.value, ...progress }
+    return this.set(next)
+  }
   public setStepComplete = (tutorial: TT.Tutorial, stepId: string): T.Progress => {
     const next = this.value
     // mark step complete

--- a/web-app/src/containers/Tutorial/components/Level.tsx
+++ b/web-app/src/containers/Tutorial/components/Level.tsx
@@ -87,18 +87,33 @@ const styles = {
 
 interface Props {
   menu: any
-  level: TT.Level & { status: T.ProgressStatus; index: number; steps: Array<TT.Step & { status: T.ProgressStatus }> }
+  steps: Array<TT.Step & { status: T.ProgressStatus }>
+  title: string
+  index: number
+  content: string
+  status: 'COMPLETE' | 'ACTIVE' | 'INCOMPLETE'
   processes: T.ProcessEvent[]
   testStatus: T.TestStatus | null
   onContinue(): void
   onLoadSolution(): void
 }
 
-const Level = ({ menu, level, onContinue, onLoadSolution, processes, testStatus }: Props) => {
+const Level = ({
+  menu,
+  steps,
+  title,
+  content,
+  index,
+  status,
+  onContinue,
+  onLoadSolution,
+  processes,
+  testStatus,
+}: Props) => {
   // @ts-ignore
-  let currentStep = level.steps.findIndex((s) => s.status === 'ACTIVE')
+  let currentStep = steps.findIndex((s) => s.status === 'ACTIVE')
   if (currentStep === -1) {
-    currentStep = level.steps.length
+    currentStep = steps.length
   }
 
   const pageBottomRef = React.useRef(null)
@@ -116,7 +131,7 @@ const Level = ({ menu, level, onContinue, onLoadSolution, processes, testStatus 
           <Dropdown
             trigger={
               <a css={styles.learn}>
-                Learn <Icon type="arrow-down" size="xxs" />{' '}
+                Learn <Icon type="arrow-down" size="xxs" />
               </a>
             }
             triggerType="click"
@@ -125,15 +140,15 @@ const Level = ({ menu, level, onContinue, onLoadSolution, processes, testStatus 
           </Dropdown>
         </div>
         <div css={styles.text}>
-          <h2 css={styles.title}>{level.title}</h2>
-          <Markdown>{level.content || ''}</Markdown>
+          <h2 css={styles.title}>{title}</h2>
+          <Markdown>{content || ''}</Markdown>
         </div>
 
-        {level.steps.length ? (
+        {steps.length ? (
           <div css={styles.tasks}>
             <div css={styles.header}>Tasks</div>
             <div css={styles.steps}>
-              {level.steps.map((step: (TT.Step & { status: T.ProgressStatus }) | null, index: number) => {
+              {steps.map((step: (TT.Step & { status: T.ProgressStatus }) | null, index: number) => {
                 if (!step) {
                   return null
                 }
@@ -165,17 +180,17 @@ const Level = ({ menu, level, onContinue, onLoadSolution, processes, testStatus 
 
         <div css={styles.footer}>
           <span>
-            {typeof level.index === 'number' ? `${level.index + 1}. ` : ''}
-            {level.title}
+            {typeof index === 'number' ? `${index + 1}. ` : ''}
+            {title}
           </span>
           <span>
-            {level.status === 'COMPLETE' || !level.steps.length ? (
+            {status === 'COMPLETE' || !steps.length ? (
               <Button type="primary" onClick={onContinue}>
                 Continue
               </Button>
             ) : (
               <span css={styles.taskCount}>
-                {currentStep} of {level.steps.length} tasks
+                {currentStep} of {steps.length} tasks
               </span>
             )}
           </span>

--- a/web-app/src/containers/Tutorial/components/Level.tsx
+++ b/web-app/src/containers/Tutorial/components/Level.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import * as T from 'typings'
 import * as TT from 'typings/tutorial'
 import { css, jsx } from '@emotion/core'
+import { Dropdown } from '@alifd/next'
+import Icon from '../../../components/Icon'
 import Button from '../../../components/Button'
 import Markdown from '../../../components/Markdown'
 import ProcessMessages from '../../../components/ProcessMessages'
@@ -22,11 +24,18 @@ const styles = {
     paddingBottom: '5rem',
   },
   header: {
+    display: 'flex' as 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     height: '2rem',
     backgroundColor: '#EBEBEB',
     fontSize: '1rem',
     lineHeight: '1rem',
     padding: '10px 1rem',
+  },
+  learn: {
+    textDecoration: 'none',
+    color: 'inherit',
   },
   text: {
     padding: '0rem 1rem',
@@ -77,6 +86,7 @@ const styles = {
 }
 
 interface Props {
+  menu: any
   level: TT.Level & { status: T.ProgressStatus; index: number; steps: Array<TT.Step & { status: T.ProgressStatus }> }
   processes: T.ProcessEvent[]
   testStatus: T.TestStatus | null
@@ -84,7 +94,7 @@ interface Props {
   onLoadSolution(): void
 }
 
-const Level = ({ level, onContinue, onLoadSolution, processes, testStatus }: Props) => {
+const Level = ({ menu, level, onContinue, onLoadSolution, processes, testStatus }: Props) => {
   // @ts-ignore
   let currentStep = level.steps.findIndex((s) => s.status === 'ACTIVE')
   if (currentStep === -1) {
@@ -103,7 +113,16 @@ const Level = ({ level, onContinue, onLoadSolution, processes, testStatus }: Pro
     <div css={styles.page}>
       <div css={styles.content}>
         <div css={styles.header}>
-          <span>Learn</span>
+          <Dropdown
+            trigger={
+              <a css={styles.learn}>
+                Learn <Icon type="arrow-down" size="xxs" />{' '}
+              </a>
+            }
+            triggerType="click"
+          >
+            {menu}
+          </Dropdown>
         </div>
         <div css={styles.text}>
           <h2 css={styles.title}>{level.title}</h2>

--- a/web-app/src/containers/Tutorial/index.tsx
+++ b/web-app/src/containers/Tutorial/index.tsx
@@ -17,6 +17,8 @@ const TutorialPage = (props: PageProps) => {
 
   const tutorial = selectors.currentTutorial(props.context)
   const levelData: TT.Level = selectors.currentLevel(props.context)
+
+  const [title, setTitle] = React.useState<string>(levelData.title)
   const [content, setContent] = React.useState<string>(levelData.content)
 
   const onContinue = (): void => {
@@ -43,6 +45,14 @@ const TutorialPage = (props: PageProps) => {
     return { ...step, status }
   })
 
+  const setMenuContent = (levelId: string) => {
+    const selectedLevel: TT.Level | undefined = tutorial.levels.find((l: TT.Level) => l.id === levelId)
+    if (selectedLevel) {
+      setTitle(selectedLevel.title)
+      setContent(selectedLevel.content)
+    }
+  }
+
   const menu = (
     <Menu>
       {tutorial.levels.map((level: TT.Level) => {
@@ -61,7 +71,7 @@ const TutorialPage = (props: PageProps) => {
           icon = <Icon type="minus" size="xs" />
         }
         return (
-          <Menu.Item key={level.id} disabled={disabled}>
+          <Menu.Item key={level.id} disabled={disabled} onSelect={() => setMenuContent(level.id)}>
             {icon}&nbsp;&nbsp;&nbsp;{level.title}
           </Menu.Item>
         )
@@ -71,7 +81,7 @@ const TutorialPage = (props: PageProps) => {
 
   return (
     <Level
-      title={levelData.title}
+      title={title}
       content={content}
       menu={menu}
       index={tutorial.levels.findIndex((l: TT.Level) => l.id === position.levelId)}

--- a/web-app/src/containers/Tutorial/index.tsx
+++ b/web-app/src/containers/Tutorial/index.tsx
@@ -5,7 +5,7 @@ import { Menu } from '@alifd/next'
 import * as selectors from '../../services/selectors'
 import Icon from '../../components/Icon'
 import Level from './components/Level'
-import logger from 'services/logger'
+import logger from '../../services/logger'
 
 interface PageProps {
   context: T.MachineContext

--- a/web-app/src/containers/Tutorial/index.tsx
+++ b/web-app/src/containers/Tutorial/index.tsx
@@ -63,12 +63,15 @@ const TutorialPage = (props: PageProps) => {
         let disabled = false
 
         if (isComplete) {
-          icon = <Icon type="success" size="xs" />
-        } else if (isCurrent) {
-          icon = <Icon type="eye" size="xs" />
-        } else {
-          disabled = true
+          // completed icon
           icon = <Icon type="minus" size="xs" />
+        } else if (isCurrent) {
+          // current icon`
+          icon = <Icon type="minus" size="xs" />
+        } else {
+          // upcoming
+          disabled = true
+          icon = <Icon type="lock" size="xs" />
         }
         return (
           <Menu.Item key={level.id} disabled={disabled} onSelect={() => setMenuContent(level.id)}>

--- a/web-app/src/containers/Tutorial/index.tsx
+++ b/web-app/src/containers/Tutorial/index.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react'
 import * as T from 'typings'
 import * as TT from 'typings/tutorial'
+import { Menu } from '@alifd/next'
 import * as selectors from '../../services/selectors'
+import Icon from '../../components/Icon'
 import Level from './components/Level'
+import logger from 'services/logger'
 
 interface PageProps {
   context: T.MachineContext
@@ -48,8 +51,35 @@ const TutorialPage = (props: PageProps) => {
     }),
   }
 
+  const menu = (
+    <Menu>
+      {tutorial.levels.map((level: TT.Level) => {
+        const isCurrent = level.id === position.levelId
+        logger('progress', progress)
+        const isComplete = progress.levels[level.id]
+        let icon
+        let disabled = false
+
+        if (isComplete) {
+          icon = <Icon type="success" size="xs" />
+        } else if (isCurrent) {
+          icon = <Icon type="eye" size="xs" />
+        } else {
+          disabled = true
+          icon = <Icon type="minus" size="xs" />
+        }
+        return (
+          <Menu.Item key={level.id} disabled={disabled}>
+            {icon}&nbsp;&nbsp;&nbsp;{level.title}
+          </Menu.Item>
+        )
+      })}
+    </Menu>
+  )
+
   return (
     <Level
+      menu={menu}
       level={level}
       onContinue={onContinue}
       onLoadSolution={onLoadSolution}

--- a/web-app/src/containers/Tutorial/index.tsx
+++ b/web-app/src/containers/Tutorial/index.tsx
@@ -17,6 +17,7 @@ const TutorialPage = (props: PageProps) => {
 
   const tutorial = selectors.currentTutorial(props.context)
   const levelData: TT.Level = selectors.currentLevel(props.context)
+  const [content, setContent] = React.useState<string>(levelData.content)
 
   const onContinue = (): void => {
     props.send({
@@ -31,25 +32,16 @@ const TutorialPage = (props: PageProps) => {
     props.send({ type: 'STEP_SOLUTION_LOAD' })
   }
 
-  const level: TT.Level & {
-    status: T.ProgressStatus
-    index: number
-    steps: Array<TT.Step & { status: T.ProgressStatus }>
-  } = {
-    ...levelData,
-    index: tutorial.levels.findIndex((l: TT.Level) => l.id === position.levelId),
-    status: progress.levels[position.levelId] ? 'COMPLETE' : 'ACTIVE',
-    steps: levelData.steps.map((step: TT.Step) => {
-      // label step status for step component
-      let status: T.ProgressStatus = 'INCOMPLETE'
-      if (progress.steps[step.id]) {
-        status = 'COMPLETE'
-      } else if (step.id === position.stepId) {
-        status = 'ACTIVE'
-      }
-      return { ...step, status }
-    }),
-  }
+  const steps = levelData.steps.map((step: TT.Step) => {
+    // label step status for step component
+    let status: T.ProgressStatus = 'INCOMPLETE'
+    if (progress.steps[step.id]) {
+      status = 'COMPLETE'
+    } else if (step.id === position.stepId) {
+      status = 'ACTIVE'
+    }
+    return { ...step, status }
+  })
 
   const menu = (
     <Menu>
@@ -79,8 +71,12 @@ const TutorialPage = (props: PageProps) => {
 
   return (
     <Level
+      title={levelData.title}
+      content={content}
       menu={menu}
-      level={level}
+      index={tutorial.levels.findIndex((l: TT.Level) => l.id === position.levelId)}
+      steps={steps}
+      status={progress.levels[position.levelId] ? 'COMPLETE' : 'ACTIVE'}
       onContinue={onContinue}
       onLoadSolution={onLoadSolution}
       processes={processes}

--- a/web-app/src/environment.ts
+++ b/web-app/src/environment.ts
@@ -9,7 +9,6 @@ for (const required of requiredKeys) {
 export const DEBUG: boolean = (process.env.REACT_APP_DEBUG || '').toLowerCase() === 'true'
 export const VERSION: string = process.env.VERSION || 'unknown'
 export const NODE_ENV: string = process.env.NODE_ENV || 'development'
-export const LOG: boolean =
-  (process.env.REACT_APP_LOG || '').toLowerCase() === 'true' && process.env.NODE_ENV !== 'production'
+export const LOG: boolean = (process.env.REACT_APP_LOG || '').toLowerCase() === 'true'
 export const TUTORIAL_LIST_URL: string = process.env.REACT_APP_TUTORIAL_LIST_URL || ''
 export const SENTRY_DSN: string | null = process.env.REACT_APP_SENTRY_DSN || null

--- a/web-app/src/services/state/actions/editor.ts
+++ b/web-app/src/services/state/actions/editor.ts
@@ -74,6 +74,14 @@ export default (editorSend: any) => ({
       })
     }
   },
+  syncLevelProgress(context: CR.MachineContext): void {
+    editorSend({
+      type: 'EDITOR_SYNC_PROGRESS',
+      payload: {
+        progress: context.progress,
+      },
+    })
+  },
   clearStorage(): void {
     editorSend({ type: 'TUTORIAL_CLEAR' })
   },

--- a/web-app/src/services/state/machine.ts
+++ b/web-app/src/services/state/machine.ts
@@ -207,13 +207,12 @@ export const createMachine = (options: any) => {
                       target: 'Normal',
                       actions: ['loadStep'],
                     },
-                    LEVEL_COMPLETE: {
-                      target: 'LevelComplete',
-                      actions: ['updateLevelProgress'],
-                    },
+                    LEVEL_COMPLETE: 'LevelComplete',
                   },
                 },
                 LevelComplete: {
+                  onEntry: ['updateLevelProgress'],
+                  onExit: ['syncLevelProgress'],
                   on: {
                     LEVEL_NEXT: {
                       target: '#tutorial-load-next',

--- a/web-app/stories/Level.stories.tsx
+++ b/web-app/stories/Level.stories.tsx
@@ -39,7 +39,7 @@ storiesOf('Level', module)
       description: 'A summary of the level',
       content: 'Some content here in markdown',
       setup: null,
-      status: 'ACTIVE',
+      status: 'ACTIVE' as 'ACTIVE',
       steps: [
         {
           id: 'L1:S1',
@@ -88,7 +88,11 @@ storiesOf('Level', module)
     return (
       <Level
         menu={menu}
-        level={level}
+        title={level.title}
+        content={level.content}
+        index={0}
+        status={level.status}
+        steps={level.steps}
         onContinue={action('onContinue')}
         onLoadSolution={action('onLoadSolution')}
         processes={[]}
@@ -104,6 +108,7 @@ storiesOf('Level', module)
       description: 'A description',
       content: 'Should support markdown test\n ```js\nvar a = 1\n```\nwhew it works!',
       setup: { commits: ['77e57cd'], commands: ['npm install'], files: [] },
+      status: 'ACTIVE' as 'ACTIVE',
       steps: [
         {
           id: 'L1:S1',
@@ -143,7 +148,11 @@ storiesOf('Level', module)
     return (
       <Level
         menu={menu}
-        level={level}
+        title={level.title}
+        content={level.content}
+        index={0}
+        status={level.status}
+        steps={level.steps}
         onContinue={action('onContinue')}
         onLoadSolution={action('onLoadSolution')}
         processes={[
@@ -167,6 +176,7 @@ storiesOf('Level', module)
         commits: ['6adeb95'],
         commands: ['npm install'],
       },
+      status: 'ACTIVE' as 'ACTIVE',
       steps: [
         {
           id: 'L1:S1',
@@ -227,7 +237,11 @@ storiesOf('Level', module)
     return (
       <Level
         menu={menu}
-        level={level}
+        title={level.title}
+        content={level.content}
+        index={0}
+        status={level.status}
+        steps={level.steps}
         onContinue={action('onContinue')}
         onLoadSolution={action('onLoadSolution')}
         processes={[]}
@@ -246,6 +260,7 @@ storiesOf('Level', module)
         commits: ['0d7543c'],
         commands: ['npm install'],
       },
+      status: 'ACTIVE' as 'ACTIVE',
       steps: [
         {
           id: 'L2:S1',
@@ -300,7 +315,11 @@ storiesOf('Level', module)
     return (
       <Level
         menu={menu}
-        level={level}
+        title={level.title}
+        content={level.content}
+        index={0}
+        status={level.status}
+        steps={level.steps}
         onContinue={action('onContinue')}
         onLoadSolution={action('onLoadSolution')}
         processes={[]}
@@ -316,13 +335,17 @@ storiesOf('Level', module)
       description: 'A summary of the level',
       content: 'Some content here in markdown',
       setup: null,
-      status: 'ACTIVE',
+      status: 'ACTIVE' as 'ACTIVE',
       steps: [],
     }
     return (
       <Level
         menu={menu}
-        level={level}
+        title={level.title}
+        content={level.content}
+        index={0}
+        status={level.status}
+        steps={level.steps}
         onContinue={action('onContinue')}
         onLoadSolution={action('onLoadSolution')}
         processes={[]}

--- a/web-app/stories/Level.stories.tsx
+++ b/web-app/stories/Level.stories.tsx
@@ -6,12 +6,27 @@ import * as T from '../../typings'
 import * as TT from '../../typings/tutorial'
 import Level from '../src/containers/Tutorial/components/Level'
 import SideBarDecorator from './utils/SideBarDecorator'
+import { Menu } from '@alifd/next'
+import Icon from '../src/components/Icon'
 
 type ModifiedLevel = TT.Level & {
   status: T.ProgressStatus
   index: number
   steps: Array<TT.Step & { status: T.ProgressStatus }>
 }
+
+const menu = (
+  <Menu>
+    {[{ id: '1', title: 'First' }].map((level: TT.Level) => {
+      const icon = <Icon type="eye" size="xs" />
+      return (
+        <Menu.Item key={level.id}>
+          {icon}&nbsp;&nbsp;&nbsp;{level.title}
+        </Menu.Item>
+      )
+    })}
+  </Menu>
+)
 
 storiesOf('Level', module)
   .addDecorator(SideBarDecorator)
@@ -72,6 +87,7 @@ storiesOf('Level', module)
     }
     return (
       <Level
+        menu={menu}
         level={level}
         onContinue={action('onContinue')}
         onLoadSolution={action('onLoadSolution')}
@@ -126,6 +142,7 @@ storiesOf('Level', module)
     }
     return (
       <Level
+        menu={menu}
         level={level}
         onContinue={action('onContinue')}
         onLoadSolution={action('onLoadSolution')}
@@ -209,6 +226,7 @@ storiesOf('Level', module)
     }
     return (
       <Level
+        menu={menu}
         level={level}
         onContinue={action('onContinue')}
         onLoadSolution={action('onLoadSolution')}
@@ -281,6 +299,7 @@ storiesOf('Level', module)
     }
     return (
       <Level
+        menu={menu}
         level={level}
         onContinue={action('onContinue')}
         onLoadSolution={action('onLoadSolution')}
@@ -302,6 +321,7 @@ storiesOf('Level', module)
     }
     return (
       <Level
+        menu={menu}
         level={level}
         onContinue={action('onContinue')}
         onLoadSolution={action('onLoadSolution')}


### PR DESCRIPTION
closes #274 

Allow users to travel through markdown content in the "Learn" section.

- [x] Awaiting a fix for tracking of level progress when a level has no steps