### PR TITLE
fix inline code block styles

### DIFF
--- a/web-app/src/components/Markdown/style.css
+++ b/web-app/src/components/Markdown/style.css
@@ -1,6 +1,12 @@
+.coderoad-markdown pre {
+  border-radius: 0.3rem;
+}
+
 .coderoad-markdown :not(pre) > code {
-  background-color: black;
-  color: white;
-  border-radius: 2px;
-  padding: 0.1rem;
+  background-color: rgba(27, 31, 35, 0.05);
+  color: black;
+  border-radius: 0.3rem;
+  padding: 0rem 0.15rem;
+  font-size: 80%;
+  white-space: nowrap;
 }


### PR DESCRIPTION
closes #320. Lightens inline codeblock text.

Example:

![image](https://user-images.githubusercontent.com/4660659/81463291-5747af80-916d-11ea-8e91-61658e3c42e3.png)

Signed-off-by: shmck <shawn.j.mckay@gmail.com>