### PR TITLE
markdown style fixes (strong, table)

### DIFF
--- a/web-app/src/components/Markdown/style.css
+++ b/web-app/src/components/Markdown/style.css
@@ -10,3 +10,179 @@
   font-size: 80%;
   white-space: nowrap;
 }
+
+strong {
+  font-weight: 600;
+  text-decoration-style: solid;
+}
+
+blockquote {
+  border-left: 4px solid #dddddd;
+  padding: 0 15px;
+  color: #777777;
+}
+blockquote > :first-child {
+  margin-top: 0;
+}
+blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+table {
+  padding: 0;
+  background-color: #dfe2e5;
+  margin: 6px 0px;
+}
+table tr {
+  /* border-top: 1px solid #cccccc; */
+  background-color: white;
+  margin: 0;
+  padding: 0;
+}
+table tr:nth-child(2n) {
+  background-color: #f8f8f8;
+}
+table tr th {
+  font-weight: bold;
+  /* border: 1px solid #cccccc; */
+  text-align: left;
+  margin: 0;
+  padding: 6px 13px;
+  box-sizing: border-box;
+}
+table tr td {
+  /* border: 1px solid #cccccc; */
+  text-align: left;
+  margin: 0;
+  padding: 6px 13px;
+}
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
+}
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
+}
+
+img {
+  max-width: 100%;
+}
+
+span.frame {
+  display: block;
+  overflow: hidden;
+}
+span.frame > span {
+  border: 1px solid #dddddd;
+  display: block;
+  float: left;
+  overflow: hidden;
+  margin: 13px 0 0;
+  padding: 7px;
+  width: auto;
+}
+span.frame span img {
+  display: block;
+  float: left;
+}
+span.frame span span {
+  clear: both;
+  color: #333333;
+  display: block;
+  padding: 5px 0 0;
+}
+span.align-center {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+span.align-center > span {
+  display: block;
+  overflow: hidden;
+  margin: 13px auto 0;
+  text-align: center;
+}
+span.align-center span img {
+  margin: 0 auto;
+  text-align: center;
+}
+span.align-right {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+span.align-right > span {
+  display: block;
+  overflow: hidden;
+  margin: 13px 0 0;
+  text-align: right;
+}
+span.align-right span img {
+  margin: 0;
+  text-align: right;
+}
+span.float-left {
+  display: block;
+  margin-right: 13px;
+  overflow: hidden;
+  float: left;
+}
+span.float-left span {
+  margin: 13px 0 0;
+}
+span.float-right {
+  display: block;
+  margin-left: 13px;
+  overflow: hidden;
+  float: right;
+}
+span.float-right > span {
+  display: block;
+  overflow: hidden;
+  margin: 13px auto 0;
+  text-align: right;
+}
+
+code,
+tt {
+  margin: 0 2px;
+  padding: 0 5px;
+  white-space: nowrap;
+  border: 1px solid #eaeaea;
+  background-color: #f8f8f8;
+  border-radius: 3px;
+}
+
+pre code {
+  margin: 0;
+  padding: 0;
+  white-space: pre;
+  border: none;
+  background: transparent;
+}
+
+.highlight pre {
+  background-color: #f8f8f8;
+  border: 1px solid #cccccc;
+  font-size: 13px;
+  line-height: 19px;
+  overflow: auto;
+  padding: 6px 10px;
+  border-radius: 3px;
+}
+
+pre {
+  background-color: #f8f8f8;
+  border: 1px solid #cccccc;
+  font-size: 13px;
+  line-height: 19px;
+  overflow: auto;
+  padding: 6px 10px;
+  border-radius: 3px;
+}
+pre code,
+pre tt {
+  background-color: transparent;
+  border: none;
+}

--- a/web-app/stories/Step.stories.tsx
+++ b/web-app/stories/Step.stories.tsx
@@ -8,7 +8,8 @@ import SideBarDecorator from './utils/SideBarDecorator'
 const stepText =
   'This is a long paragraph of step text intended to wrap around the side after a short period of writing to demonstrate text wrap among other things'
 
-const paragraphText = `Markdown included \`code\`, *bold*, & _italics_.
+const paragraphText = `
+  ### Code
 
   Inline code: \`<h1>HTML</h1>\`, \`function someFunc() { var a = 1; return a; }\`
 
@@ -20,7 +21,7 @@ const paragraphText = `Markdown included \`code\`, *bold*, & _italics_.
   }
   \`\`\`
 
-  Headers can be added:
+  ### Headers
 
   # h1
   ## h2
@@ -28,7 +29,30 @@ const paragraphText = `Markdown included \`code\`, *bold*, & _italics_.
   #### h4
   ##### h5
 
-  Emojis: :) :| :(
+  ### Emojis
+
+  :) :| :(
+
+  ### Text Formatting
+
+  **bold**, *italics*, ~~strikethrough~~
+
+  ### BlockQuote
+
+  > A quote here
+
+  ### Tables
+  | First Header  | Second Header |
+  | ------------- | ------------- |
+  | Content Cell  | Content Cell  |
+  | Content Cell  | Content Cell  |
+
+  
+
+  | Left-aligned | Center-aligned | Right-aligned |
+  | :---         |     :---:      |          ---: |
+  | git status   | git status     | git status    |
+  | git diff     | git diff       | git diff      |
   `
 
 storiesOf('Step', module)


### PR DESCRIPTION
closes #345.

Kicks bold up from 500 font weight to 600.
Adds styling for tables.

See below:

![image](https://user-images.githubusercontent.com/4660659/82170950-c498c600-987a-11ea-8f76-a2075733fca0.png)


Signed-off-by: shmck <shawn.j.mckay@gmail.com>