### PR TITLE
support multiple reset commands

### DIFF
--- a/src/actions/onRunReset.ts
+++ b/src/actions/onRunReset.ts
@@ -3,6 +3,7 @@ import * as TT from 'typings/tutorial'
 import Context from '../services/context/context'
 import { exec } from '../services/node'
 import reset from '../services/reset'
+import * as hooks from '../services/hooks'
 import getCommitHashByPosition from '../services/reset/lastHash'
 
 type ResetAction = {
@@ -29,9 +30,12 @@ const onRunReset = async (action: ResetAction, context: Context): Promise<void> 
   // load timeline until last pass commit
   reset({ branch, hash })
 
+  // TODO: @deprecate command in favor of commands
   // if tutorial.config.reset.command, run it
   if (tutorial?.config?.reset?.command) {
-    await exec({ command: tutorial.config.reset.command })
+    hooks.onReset([tutorial?.config?.reset?.command])
+  } else if (tutorial?.config?.reset?.commands) {
+    hooks.onReset(tutorial?.config?.reset?.commands)
   }
 }
 

--- a/src/actions/onRunReset.ts
+++ b/src/actions/onRunReset.ts
@@ -30,12 +30,10 @@ const onRunReset = async (action: ResetAction, context: Context): Promise<void> 
   // load timeline until last pass commit
   reset({ branch, hash })
 
-  // TODO: @deprecate command in favor of commands
   // if tutorial.config.reset.command, run it
-  if (tutorial?.config?.reset?.command) {
-    hooks.onReset([tutorial?.config?.reset?.command])
-  } else if (tutorial?.config?.reset?.commands) {
-    hooks.onReset(tutorial?.config?.reset?.commands)
+  const resetActions = tutorial?.config?.reset
+  if (resetActions) {
+    hooks.onReset({ commands: resetActions?.commands, vscodeCommands: resetActions?.vscodeCommands })
   }
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,8 +3,8 @@ import * as TT from 'typings/tutorial'
 import * as vscode from 'vscode'
 import createTestRunner from './services/testRunner'
 import createWebView from './services/webview'
-import logger from './services/logger'
 import * as hooks from './services/hooks'
+import logger from './services/logger'
 
 export const COMMANDS = {
   START: 'coderoad.start',

--- a/src/services/hooks/index.ts
+++ b/src/services/hooks/index.ts
@@ -38,8 +38,9 @@ export const onSolutionEnter = async (actions: TT.StepActions): Promise<void> =>
   await onRunTest()
 }
 
-export const onReset = async (commands: string[]): Promise<void> => {
-  await runCommands(commands)
+export const onReset = async (actions: TT.StepActions): Promise<void> => {
+  await runCommands(actions?.commands)
+  await runVSCodeCommands(actions?.vscodeCommands)
 }
 
 export const onError = async (error: Error): Promise<void> => {

--- a/src/services/hooks/index.ts
+++ b/src/services/hooks/index.ts
@@ -38,6 +38,10 @@ export const onSolutionEnter = async (actions: TT.StepActions): Promise<void> =>
   await onRunTest()
 }
 
+export const onReset = async (commands: string[]): Promise<void> => {
+  await runCommands(commands)
+}
+
 export const onError = async (error: Error): Promise<void> => {
   telemetryOnError(error)
 }

--- a/src/services/hooks/utils/loadCommits.ts
+++ b/src/services/hooks/utils/loadCommits.ts
@@ -1,7 +1,7 @@
 import * as git from '../../git'
 
-const loadCommits = async (commits: string[]): Promise<void> => {
-  if (commits) {
+const loadCommits = async (commits: string[] = []): Promise<void> => {
+  if (commits && commits.length) {
     // load the current list of commits for validation
     for (const commit of commits) {
       await git.loadCommit(commit)

--- a/src/services/reset/lastHash.ts
+++ b/src/services/reset/lastHash.ts
@@ -41,7 +41,7 @@ const getLastCommitHash = (position: T.Position, tutorial: TT.Tutorial | null): 
   if (!step) {
     throw new Error(`No step found matching ${stepId}`)
   }
-  const commits = step.setup.commits
+  const commits = step.setup?.commits || []
   if (!commits.length) {
     throw new Error(`No commits found on step ${stepId}`)
   }

--- a/typings/tutorial.d.ts
+++ b/typings/tutorial.d.ts
@@ -3,8 +3,8 @@ import { ProgressStatus } from './index'
 export type Maybe<T> = T | null
 
 export type ConfigReset = {
-  command?: string
   commands?: string[]
+  vscodeCommands?: VSCodeCommand[]
 }
 
 export type TutorialConfig = {
@@ -58,7 +58,7 @@ export type TutorialSummary = {
 
 export type StepActions = {
   commands?: string[]
-  commits: string[]
+  commits?: string[]
   files?: string[]
   watchers?: string[]
   filter?: string

--- a/typings/tutorial.d.ts
+++ b/typings/tutorial.d.ts
@@ -4,6 +4,7 @@ export type Maybe<T> = T | null
 
 export type ConfigReset = {
   command?: string
+  commands?: string[]
 }
 
 export type TutorialConfig = {


### PR DESCRIPTION
Supports `config.reset.commands` & `config.reset.vscodeCommands`.

Removes `config.reset.command`

Signed-off-by: shmck <shawn.j.mckay@gmail.com>