### PR TITLE
test fails with doctype

### DIFF
--- a/docs/docs/create-a-practice-tutorial.md
+++ b/docs/docs/create-a-practice-tutorial.md
@@ -285,7 +285,7 @@ describe('index.html', () => {
   })
 
   it('should have a DOCTYPE', () => {
-    assert(/<!doctype html>/i.test(indexFile))
+    assert(/<!DOCTYPE html>/i.test(indexFile))
   })
 })
 ```


### PR DESCRIPTION
This might have missed it in hindsight, but the test fails as someone follows the tutorials.

Changing it from `<!doctype html>` to `<!DOCTYPE html>` solves the problem