### PR TITLE
Resolve failed launch on CodeAlly

### DIFF
--- a/src/actions/onStartup.ts
+++ b/src/actions/onStartup.ts
@@ -42,9 +42,9 @@ const onStartup = async (context: Context): Promise<void> => {
           const tutorial = await tutorialRes.json()
           send({ type: 'START_TUTORIAL_FROM_URL', payload: { tutorial } })
           return
-        } catch (e) {
+        } catch (e: any) {
           // on failure to load a tutorial url fallback to NEW
-          console.log(`Failed to load tutorial from url ${TUTORIAL_URL} with error "${e.message}"`)
+          throw new Error(`Failed to load tutorial from url ${TUTORIAL_URL} with error "${e.message}"`)
         }
       }
       // NEW from start click
@@ -56,7 +56,7 @@ const onStartup = async (context: Context): Promise<void> => {
     const { position } = await context.onContinue(tutorial)
     // communicate to client the tutorial & stepProgress state
     send({ type: 'LOAD_STORED_TUTORIAL', payload: { env, tutorial, position } })
-  } catch (e) {
+  } catch (e: any) {
     const error = {
       type: 'UnknownError',
       message: `Location: Editor startup\n\n${e.message}`,

--- a/src/actions/onTutorialConfigContinue.ts
+++ b/src/actions/onTutorialConfigContinue.ts
@@ -25,7 +25,7 @@ const onTutorialConfigContinue = async (action: T.Action, context: Context): Pro
     if (tutorialToContinue.config?.webhook) {
       setupWebhook(tutorialToContinue.config.webhook)
     }
-  } catch (e) {
+  } catch (e: any) {
     const error = {
       type: 'UnknownError',
       message: `Location: Editor tutorial continue config.\n\n ${e.message}`,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -20,6 +20,11 @@ class Channel implements Channel {
 
   // receive from webview
   public receive = async (action: T.Action): Promise<void> => {
+    if (action.source !== 'coderoad') {
+      // filter out events from other extensions
+      return
+    }
+
     // action may be an object.type or plain string
     const actionType: string = typeof action === 'string' ? action : action.type
 

--- a/src/services/hooks/utils/openFiles.ts
+++ b/src/services/hooks/utils/openFiles.ts
@@ -15,7 +15,7 @@ const openFiles = async (files: string[] = []): Promise<void> => {
       const absoluteFilePath = join(wr, filePath)
       const doc = await vscode.workspace.openTextDocument(absoluteFilePath)
       await vscode.window.showTextDocument(doc, vscode.ViewColumn.One)
-    } catch (error) {
+    } catch (error: any) {
       console.log(`Failed to open file ${filePath}: ${error.message}`)
     }
   }

--- a/src/services/hooks/utils/runCommands.ts
+++ b/src/services/hooks/utils/runCommands.ts
@@ -15,7 +15,7 @@ const runCommands = async (commands: string[] = []): Promise<void> => {
     try {
       result = await exec({ command })
       console.log(result)
-    } catch (error) {
+    } catch (error: any) {
       console.error(`Command failed: ${error.message}`)
       send({ type: 'COMMAND_FAIL', payload: { process: { ...process, status: 'FAIL' } } })
       return

--- a/src/services/reset/index.ts
+++ b/src/services/reset/index.ts
@@ -63,7 +63,7 @@ const reset = async ({ branch, hash }: Input): Promise<void> => {
     await exec({
       command: `git reset --hard ${hash}`,
     })
-  } catch (error) {
+  } catch (error: any) {
     console.error('Error resetting')
     console.error(error.message)
   }

--- a/src/services/testRunner/index.ts
+++ b/src/services/testRunner/index.ts
@@ -75,7 +75,7 @@ const createTestRunner = (data: TT.Tutorial, callbacks: Callbacks): ((params: an
       }
       logger('COMMAND', command)
       result = await exec({ command, dir: testRunnerConfig.directory })
-    } catch (err) {
+    } catch (err: any) {
       result = { stdout: err.stdout, stderr: err.stack }
     }
 

--- a/src/services/webview/create.ts
+++ b/src/services/webview/create.ts
@@ -56,7 +56,11 @@ const createReactWebView = ({ extensionPath, channel }: ReactWebViewProps): Outp
 
   // Handle messages from the webview
   const receive = channel.receive
-  const send = (action: T.Action) => panel.webview.postMessage(action)
+  const send = (action: T.Action) =>
+    panel.webview.postMessage({
+      ...action,
+      source: 'coderoad', // filter events on client by source. origin is not reliable
+    })
 
   panel.webview.onDidReceiveMessage(receive, null, disposables)
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -49,6 +49,7 @@ export interface Position {
 // current tutorial state
 
 export interface Action {
+  source?: 'coderoad' // filter received actions by this
   type: string
   payload?: any
   meta?: any


### PR DESCRIPTION
Resolves issue with CodeRoad not working on CodeAlly.

The event origin changed to "codeally.com" instead of "vscode-webview", which was used to filter noisy vscode events.

This PR adds a new field of `souce: "coderoad"` for event filtering.

https://github.com/freeCodeCamp/CodeAlly-CodeRoad-freeCodeCamp/issues/26