### PR TITLE
prioritize session file path over local storage

### DIFF
--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -30,7 +30,6 @@ class Storage<T> {
     this.defaultValue = defaultValue
   }
   public get = async (): Promise<T> => {
-    const value: string | undefined = await this.storage.get(this.key)
     if (SESSION_STORAGE_PATH) {
       try {
         // 1. read from file instead of local storage if specified
@@ -51,6 +50,7 @@ class Storage<T> {
         console.warn(`Failed to read or parse session file: ${SESSION_STORAGE_PATH}/${this.filePath}.json`)
       }
     }
+    const value: string | undefined = await this.storage.get(this.key)
     if (value) {
       // 2. read from local storage
       try {

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -31,11 +31,9 @@ class Storage<T> {
   }
   public get = async (): Promise<T> => {
     const value: string | undefined = await this.storage.get(this.key)
-    if (value) {
-      return JSON.parse(value)
-    } else if (SESSION_STORAGE_PATH) {
+    if (SESSION_STORAGE_PATH) {
       try {
-        // optionally read from file as a fallback to local storage
+        // 1. read from file instead of local storage if specified
         const sessionFile = await readFile(SESSION_STORAGE_PATH, `${this.filePath}.json`)
         if (!sessionFile) {
           throw new Error('No session file found')
@@ -53,6 +51,15 @@ class Storage<T> {
         console.warn(`Failed to read or parse session file: ${SESSION_STORAGE_PATH}/${this.filePath}.json`)
       }
     }
+    if (value) {
+      // 2. read from local storage
+      try {
+        return JSON.parse(value)
+      } catch (err) {
+        console.warn(`Failed to parse session state from local storage: ${value}`)
+      }
+    }
+    // 3. fallback to the default
     return this.defaultValue
   }
   public set = (value: T): void => {


### PR DESCRIPTION
If the session storage path is specified, prioritize the file over local storage.

Should help resolve a multi-container restart issue on codeally.

Signed-off-by: shmck <shawn.j.mckay@gmail.com>