### PR TITLE
add onContinue hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "coderoad-vscode" extension will be documented in thi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+# [0.19.0]
+
+- Add the ability to run scripts on continue to address an issue where continued tutorials weren't configured correctly.
+    - adds a "continue" webhook
+    - adds a `tutorial.config.continue` that lets you run `commands` or `vscodeCommands`
+
 ## [0.18.0]
 
 - Improved error logging in output channel "CodeRoad (Logs)"
@@ -18,10 +24,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [0.17.0]
 
-- auto-launch a continued tutorial
+- Auto-launch a continued tutorial
 ## [0.16.0]
 
-- add support for writing session state to a file. This is useful in multi-container environments where local storage is not necessarily preserved across sessions.
+- Add support for writing session state to a file. This is useful in multi-container environments where local storage is not necessarily preserved across sessions.
 
 ## [0.15.1]
 

--- a/src/actions/onTutorialConfigContinue.ts
+++ b/src/actions/onTutorialConfigContinue.ts
@@ -28,10 +28,10 @@ const onTutorialConfigContinue = async (action: T.Action, context: Context): Pro
     }
 
     // if tutorial.config.reset.command, run it
-    const resetActions = tutorialToContinue?.config?.continue
-    if (resetActions) {
-      hooks.onReset(
-        { commands: resetActions?.commands, vscodeCommands: resetActions?.vscodeCommands },
+    const continueActions = tutorialToContinue?.config?.continue
+    if (continueActions) {
+      hooks.onContinue(
+        { commands: continueActions?.commands, vscodeCommands: continueActions?.vscodeCommands },
         tutorialToContinue?.id as string,
       )
     }

--- a/src/actions/onTutorialConfigContinue.ts
+++ b/src/actions/onTutorialConfigContinue.ts
@@ -6,6 +6,7 @@ import tutorialConfig from './utils/tutorialConfig'
 import { COMMANDS, send } from '../commands'
 import logger from '../services/logger'
 import { setupWebhook } from '../services/hooks/webhooks'
+import * as hooks from '../services/hooks'
 
 const onTutorialConfigContinue = async (action: T.Action, context: Context): Promise<void> => {
   try {
@@ -24,6 +25,15 @@ const onTutorialConfigContinue = async (action: T.Action, context: Context): Pro
     // configure webhook
     if (tutorialToContinue.config?.webhook) {
       setupWebhook(tutorialToContinue.config.webhook)
+    }
+
+    // if tutorial.config.reset.command, run it
+    const resetActions = tutorialToContinue?.config?.continue
+    if (resetActions) {
+      hooks.onReset(
+        { commands: resetActions?.commands, vscodeCommands: resetActions?.vscodeCommands },
+        tutorialToContinue?.id as string,
+      )
     }
   } catch (e: any) {
     const error = {

--- a/src/services/hooks/index.ts
+++ b/src/services/hooks/index.ts
@@ -56,6 +56,15 @@ export const onReset = async (actions: TT.StepActions, tutorialId: string): Prom
   })
 }
 
+// run when a tutorial is continued
+export const onContinue = async (actions: TT.StepActions, tutorialId: string): Promise<void> => {
+  await runCommands(actions?.commands)
+  await runVSCodeCommands(actions?.vscodeCommands)
+  webhooks.onContinue({
+    tutorialId,
+  })
+}
+
 // run when an uncaught exception is thrown
 export const onError = async (error: Error): Promise<void> => {
   telemetry.onError(error)

--- a/src/services/hooks/webhooks.ts
+++ b/src/services/hooks/webhooks.ts
@@ -6,6 +6,7 @@ import { WEBHOOK_TOKEN } from '../../environment'
 const WEBHOOK_EVENTS = {
   init: false,
   reset: false,
+  continue: false,
   step_complete: false,
   level_complete: false,
   tutorial_complete: false,
@@ -73,6 +74,16 @@ type WebhookEventReset = {
 export const onReset = (event: WebhookEventReset): void => {
   if (WEBHOOK_EVENTS.reset) {
     callWebhookEndpoint<WebhookEventReset>(event)
+  }
+}
+
+type WebhookEventContinue = {
+  tutorialId: string
+}
+
+export const onContinue = (event: WebhookEventReset): void => {
+  if (WEBHOOK_EVENTS.continue) {
+    callWebhookEndpoint<WebhookEventContinue>(event)
   }
 }
 

--- a/typings/tutorial.d.ts
+++ b/typings/tutorial.d.ts
@@ -2,7 +2,7 @@ import { ProgressStatus } from './index'
 
 export type Maybe<T> = T | null
 
-export type ConfigReset = {
+export type ConfigCommands = {
   commands?: string[]
   vscodeCommands?: VSCodeCommand[]
 }
@@ -13,7 +13,8 @@ export type TutorialConfig = {
   repo: TutorialRepo
   dependencies?: TutorialDependency[]
   setup?: StepActions
-  reset?: ConfigReset
+  continue?: ConfigCommands
+  reset?: ConfigCommands
   webhook?: WebhookConfig
 }
 
@@ -97,6 +98,7 @@ export type VSCodeCommand = string | [string, any]
 export interface WebhookConfigEvents {
   init?: boolean
   reset?: boolean
+  continue?: boolean
   step_complete?: boolean
   level_complete?: boolean
   tutorial_complete?: boolean


### PR DESCRIPTION
I've added a continue hook that will let you run any commands or vscodeCommands.

```
tutorial.config.continue: { commands: [], vscodeCommands: [] }
```

I've also added a webhook if needed to track continued tutorials.

```
tutorial.webhook.events.continue
```

Signed-off-by: shmck <shawn.j.mckay@gmail.com>