### PR TITLE
feat(web-view): use `--vscode-editor-font-size` variable

### DIFF
--- a/web-app/src/components/Markdown/style.css
+++ b/web-app/src/components/Markdown/style.css
@@ -1,3 +1,7 @@
+.coderoad-markdown {
+  font-size: var(--vscode-editor-font-size, 12px);
+}
+
 .coderoad-markdown pre {
   border-radius: 0.3rem;
 }


### PR DESCRIPTION
Closes: https://github.com/freeCodeCamp/CodeAlly-CodeRoad-freeCodeCamp/issues/56

Uses the `--vscode-editor-font-size` css variable so that the `editor.fontSize` property in `settings.json` can increase the font-size of the markdown.

_I was in the neighbourhood, and decided to contribute_

**Note:** There are [other variables](https://code.visualstudio.com/api/extension-guides/webview#theming-webview-content) you might want to consider adding as well.

<details>
 <summary>Image</summary>

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/51722130/185397416-8192272f-5863-4150-a8ed-336267f38b63.png">

</details>

Signed-off-by: Shaun Hamilton <shauhami020@gmail.com>